### PR TITLE
Preserve whitespace in supervisor config when missing env vars

### DIFF
--- a/supervisor.conf.tmpl
+++ b/supervisor.conf.tmpl
@@ -34,7 +34,7 @@ priority=2
 command=/run-nginx.sh
 autorestart=true
 priority=3
-{%- endif -%}
+{%- endif %}
 
 [program:nullmailer]
 command=/run-nullmailer.sh


### PR DESCRIPTION
Previously, if VAR_WATCH and VAR_SSL were both undefined, the whitespace between the `program:program` and `program:nullmailer` sections was being removed, creating an invalid config file and preventing `run-program.sh` from actually running.